### PR TITLE
Fix conflicting dependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   "author": "Jacob Rios <rios.jacob@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "lodash.noop": "^3.0.1",
-    "react": "^15.4.2",
-    "valour": "0.0.24"
+    "lodash.noop": "^3.0.1"
   },
   "peerDependencies": {
     "react": ">=0.14",
@@ -31,6 +29,8 @@
     "babel-cli": "^6.22.2",
     "babel-plugin-transform-class-properties": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
-    "babel-preset-react": "^6.22.0"
+    "babel-preset-react": "^6.22.0",
+    "react": "^15.4.2",
+    "valour": "0.0.24"
   }
 }


### PR DESCRIPTION
For projects still on `react@0.14` this will prevent `v15.x` from being pulled down by accident.