### PR TITLE
Register Valour Callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "author": "Jacob Rios <rios.jacob@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "lodash.first": "^3.0.0",
+    "lodash.isequal": "^4.5.0",
     "lodash.noop": "^3.0.1"
   },
   "peerDependencies": {

--- a/src/wrap-component-with-valour.js
+++ b/src/wrap-component-with-valour.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import valour from 'valour';
 import noop from 'lodash.noop';
+import isEqual from 'lodash.isequal';
+import first from 'lodash.first';
 
 export default function wrapComponentWithValour(WrappedComponent) {
   return class ValidatedComponent extends React.Component {
@@ -9,6 +11,7 @@ export default function wrapComponentWithValour(WrappedComponent) {
 
       this.state = { isValid: true };
       this.setValidationStateForValue = this.setValidationStateForValue.bind(this);
+      this.setValidationResult = this.setValidationResult.bind(this);
     }
 
     static propTypes = {
@@ -21,12 +24,14 @@ export default function wrapComponentWithValour(WrappedComponent) {
       ]),
       rules: React.PropTypes.object.isRequired,
       onValidationStateChanged: React.PropTypes.func,
-      shouldRenderValidationState: React.PropTypes.bool
+      shouldRenderValidationState: React.PropTypes.bool,
+      forceRevalidation: React.PropTypes.bool
     }
 
     static defaultProps = {
       onValidationStateChanged: noop,
-      shouldRenderValidationState: true
+      shouldRenderValidationState: true,
+      forceRevalidation: false
     }
 
     componentWillMount() {
@@ -36,27 +41,43 @@ export default function wrapComponentWithValour(WrappedComponent) {
     componentDidMount() {
       this.setValidationStateForValue(this.props.valueName,
                                       this.props.value);
+
+      valour.onUpdated(this.props.formName, results => {
+        const { value } = this.state;
+        const { valueName } = this.props;
+        const result = results[valueName];
+
+        this.setValidationResult(result, value);
+      });
     }
 
     componentWillUnmount() {
       valour.disposeForm(this.props.formName);
     }
 
+    setValidationResult(result, value) {
+      const { valueName, onValidationStateChanged, forceRevalidation } = this.props;
+      const { previousValidationResult, value: oldValue } = this.state;
+
+      if (isEqual(previousValidationResult, result) && value === oldValue && !forceRevalidation) {
+        return;
+      }
+
+      const isValid = result.isValid || false;
+      const message = first(result.messages) || null;
+      const nextState = { isValid, message, value, previousValidationResult: result };
+      this.setState(nextState, () => onValidationStateChanged(valueName, value, isValid, message));
+    }
+
     setValidationStateForValue(valueName, value) {
-      const {
-        formName,
-        onValidationStateChanged
-      } = this.props;
+      const { formName, } = this.props;
 
       valour.runValidationSync(formName, {
-        [`${valueName}`]: value
+        [valueName]: value
       });
 
       const validationResult = valour.getResult(formName)[valueName];
-      const isValid = validationResult.valid !== undefined ? validationResult.valid : false;
-      const message = validationResult.messages !== undefined ? validationResult.messages[0] : null;
-      const newState = { isValid, message };
-      this.setState(newState, () => onValidationStateChanged(valueName, value, isValid, message));
+      this.setValidationResult(validationResult, value);
     }
 
     render() {


### PR DESCRIPTION
* Listen for `valour.runValidation()` and `valour.forceValidation()` calls
* Prevent unnecessary updates when neither value nor validation has
updated when callbacks are called
* Allow revalidation to be forced when callbacks are made